### PR TITLE
Function to look up ASIN from UPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# DSSG2016-UnsafeFoods
+# Mining Online Data for Early Identification of Unsafe Food Products
+
+Materials for the
+[Mining Online Data for Early Identification of Unsafe Food Products](http://escience.washington.edu/dssg/project-summaries-2016/)
+project from the UW eScience Institute's
+[Data Science for Social Good](http://escience.washington.edu/dssg/) program.
+
+## Files
+
+* `data-preprocessing.py`: Functions for data processing

--- a/data-preprocessing.py
+++ b/data-preprocessing.py
@@ -1,11 +1,17 @@
 import requests
+import re
 from time import sleep
 
 def getASIN(upc):
-    """Query upctoasin.com for the UPC, return ASIN, and wait one second (per rate
-    limiting instructions)
+    """Query upctoasin.com to determine ASIN from UPC.
+
+    First remove any non-numeric characters from the UPC (UPCs are often 
+    provided with dashes between certain digits). Query the website and
+    retrieve ASIN, then wait one second.
+
     """
-    url = "http://upctoasin.com/" + upc
+    upc_dig = re.sub("[^0-9]", "", upc)
+    url = "http://upctoasin.com/" + upc_dig
     response = requests.get(url)
     sleep(1) # Sleep for one second
     return(response.text)

--- a/data-preprocessing.py
+++ b/data-preprocessing.py
@@ -9,6 +9,18 @@ def getASIN(upc):
     provided with dashes between certain digits). Query the website and
     retrieve ASIN, then wait one second.
 
+    SAMPLE USAGE
+    ------------
+
+    # Look up a single UPC
+    getASIN("876063002233")
+
+    # Loop over multiple UPCs. One of the below returns UPCNOTFOUND, presumably
+    # because this UPC does not have an ASIN because it's not sold by Amazon:
+    upc = ["876063002233", "013000006408", "895296001035", "0-86069-20030-8"]
+    for i in upc:
+        print(getASIN(i))
+
     """
     upc_dig = re.sub("[^0-9]", "", upc)
     url = "http://upctoasin.com/" + upc_dig

--- a/data-preprocessing.py
+++ b/data-preprocessing.py
@@ -1,0 +1,11 @@
+import requests
+from time import sleep
+
+def getASIN(upc):
+    """Query upctoasin.com for the UPC, return ASIN, and wait one second (per rate
+    limiting instructions)
+    """
+    url = "http://upctoasin.com/" + upc
+    response = requests.get(url)
+    sleep(1) # Sleep for one second
+    return(response.text)


### PR DESCRIPTION
This function takes a UPC code as a string, strips any non-numeric characters (like dashes), and queries [UPCtoASIN.com](http://upctoasin.com/) to retrieve the ASIN. If no ASIN can be found, the UPCtoASIN API returns `UPCNOTFOUND`. The function has a 1-second sleep built in because the UPCtoASIN API is rate limited.
