### PR TITLE
LDA with Amazon review data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ project from the UW eScience Institute's
   file of UPCs
 * `upcs/` folder contains all of the UPCs from the FDA recalls, split into four
   files
-* `data/reviews_Grocery_and_Gourmet_Food.json.gz` is from
+* `data/raw/reviews_Grocery_and_Gourmet_Food.json.gz` is from
   http://jmcauley.ucsd.edu/data/amazon/links.html -- scroll down to
   "Per-category files" and select the Grocery and Gourmet Food reviews file.
   Note this is NOT the 5-core reviews file that appears under the "Files" header
-  on the web page. This data file should have 1,297,156 reviews.
-* `data/FDA_recalls.xml` -- this is the FDA recall data in XML form. In theory,
+  on the web page. This data file should have 1,297,156 reviews. This file is
+  not strict JSON, but can be converted to strict JSON with
+  `amz-reviews-to-strict-json.py`, which will output a file to the
+  `data/processed/` folder.
+* `data/raw/FDA_recalls.xml` -- this is the FDA recall data in XML form. In theory,
   this data should be available from data.gov at
   https://catalog.data.gov/dataset/all-fda-recalls-1ae7b, however the link on
   that page is broken. We used the Wayback machine to access a previous version
@@ -56,15 +59,20 @@ DSSG2016-UnsafeFoods/
 ├── .gitignore
 ├── README.md
 ├── asins
-│   └── asins-1.txt
+│   ├── asins-1.txt
+│   ├── asins-2.txt
+│   └── asins-3.txt
 ├── code
-│   ├── data-preprocessing.py
+│   ├── amz-reviews-lda.R
+│   ├── amz-reviews-to-strict-json.py
+│   └── data-preprocessing.py
 ├── data
 │   ├── processed
-│   │   └── FDA_recalls.csv
+│   │   ├── FDA_recalls.csv
+│   │   └── reviews_Grocery_and_Gourmet_Food_strict.json
 │   └── raw
 │       ├── FDA_recalls.xml
-│       ├── reviews_Grocery_and_Gourmet_Food.json.gz
+│       └── reviews_Grocery_and_Gourmet_Food.json.gz
 ├── notebooks
 │   ├── Fetching\ ASINs\ (FINALLY).ipynb
 │   └── NLTK\ Workbook.ipynb

--- a/code/amz-reviews-lda.R
+++ b/code/amz-reviews-lda.R
@@ -1,0 +1,102 @@
+##########################################################
+####  Visualizing topics in Amazon reviews using LDA  ####
+##########################################################
+
+## LDA code from: http://cpsievert.github.io/LDAvis/reviews/reviews.html
+
+library("jsonlite")
+library("lda")
+library("tm")
+library("LDAvis")
+library("servr")
+
+## Load Amazon review data
+json_file <- "../data/processed/reviews_Grocery_and_Gourmet_Food_strict.json"
+amz <- fromJSON(sprintf("[%s]", paste(readLines(json_file), collapse=",")))
+
+## Take a random sample of 4000 reviews (so the code doesn't take forever)
+set.seed(20)
+reviews <- sample(amz$reviewText, 4000)
+
+## read in some stopwords:
+stop_words <- stopwords("SMART")
+
+## pre-processing:
+reviews <- gsub("'", "", reviews)  # remove apostrophes
+reviews <- gsub("[[:punct:]]", " ", reviews)  # replace punctuation with space
+reviews <- gsub("[[:cntrl:]]", " ", reviews)  # replace control characters with space
+reviews <- gsub("^[[:space:]]+", "", reviews) # remove whitespace at beginning
+                                              # of documents
+reviews <- gsub("[[:space:]]+$", "", reviews) # remove whitespace at end of documents
+reviews <- tolower(reviews)  # force to lowercase
+
+## tokenize on space and output as a list:
+doc.list <- strsplit(reviews, "[[:space:]]+")
+
+## compute the table of terms:
+term.table <- table(unlist(doc.list))
+term.table <- sort(term.table, decreasing = TRUE)
+
+## remove terms that are stop words or occur fewer than 5 times:
+del <- names(term.table) %in% stop_words | term.table < 5
+term.table <- term.table[!del]
+vocab <- names(term.table)
+
+## now put the documents into the format required by the lda package:
+get.terms <- function(x) {
+  index <- match(x, vocab)
+  index <- index[!is.na(index)]
+  rbind(as.integer(index - 1), as.integer(rep(1, length(index))))
+}
+documents <- lapply(doc.list, get.terms)
+
+## Compute some statistics related to the data set:
+D <- length(documents)  # number of documents
+W <- length(vocab)  # number of terms in the vocab
+doc.length <- sapply(documents, function(x) sum(x[2, ]))  # number of tokens per
+                                                          # document
+N <- sum(doc.length)  # total number of tokens in the data
+term.frequency <- as.integer(term.table)  # frequencies of terms in the corpus
+
+# MCMC and model tuning parameters:
+K <- 15                                 # 15 topics
+G <- 5000
+alpha <- 0.02
+eta <- 0.02
+
+# Fit the model:
+
+set.seed(357)
+t1 <- Sys.time()
+fit <- lda.collapsed.gibbs.sampler(documents = documents, K = K, vocab = vocab, 
+                                   num.iterations = G, alpha = alpha, 
+                                   eta = eta, initial = NULL, burnin = 0,
+                                   compute.log.likelihood = TRUE)
+t2 <- Sys.time()
+t2 - t1                                 # Takes 3.7 minutes on Kara's machine
+
+
+## Visualizing
+theta <- t(apply(fit$document_sums + alpha, 2, function(x) x/sum(x)))
+phi <- t(apply(t(fit$topics) + eta, 2, function(x) x/sum(x)))
+
+amz_reviews <- list(phi = phi,
+                     theta = theta,
+                     doc.length = doc.length,
+                     vocab = vocab,
+                     term.frequency = term.frequency)
+
+
+
+# create the JSON object to feed the visualization:
+json <- createJSON(phi = amz_reviews$phi, 
+                   theta = amz_reviews$theta, 
+                   doc.length = amz_reviews$doc.length, 
+                   vocab = amz_reviews$vocab, 
+                   term.frequency = amz_reviews$term.frequency)
+
+serVis(json, out.dir = "../figs", open.browser = FALSE)
+
+## Serve the resulting file -- this should open a browser with an interactive
+## visualizaiton of the topics and frequent terms for each topic
+httd(dir = "../figs")

--- a/code/amz-reviews-lda.R
+++ b/code/amz-reviews-lda.R
@@ -4,6 +4,14 @@
 
 ## LDA code from: http://cpsievert.github.io/LDAvis/reviews/reviews.html
 
+## Install any necessary packages
+for (pkg in c("jsonlite", "lda", "tm", "LDAvis", "servr")) {
+  if(!pkg %in% installed.packages()) {
+    install.packages(pkg)
+  }
+}
+
+## Load packages
 library("jsonlite")
 library("lda")
 library("tm")

--- a/code/amz-reviews-to-strict-json.py
+++ b/code/amz-reviews-to-strict-json.py
@@ -1,0 +1,18 @@
+# Convert downloaded Amazon review data to strict JSON
+# Via Julian McAuley, http://jmcauley.ucsd.edu/data/amazon/links.html
+
+import json
+import gzip
+
+
+def parse(path):
+    g = gzip.open(path, 'r')
+    for l in g:
+        yield json.dumps(eval(l))
+
+    
+f = open("../data/processed/reviews_Grocery_and_Gourmet_Food_strict.json",
+         'w')
+
+for l in parse("../data/raw/reviews_Grocery_and_Gourmet_Food.json.gz"):
+    f.write(l + '\n')


### PR DESCRIPTION
Using this [example code](http://cpsievert.github.io/LDAvis/reviews/reviews.html) as a base, I did some topic modeling of the Amazon review data using latent Dirichlet allocation. I haven't tuned the model at all yet, but the resulting visualization is kind of neat (see the low-quality screencast gif):

![lda-vis](https://cloud.githubusercontent.com/assets/4452678/16467690/54c6d078-3dfd-11e6-8469-787a3040844d.gif)

To run this locally, make sure you have the Amazon review data saved as strict JSON in the `data/processed/` folder. This JSON file can be created from the compressed file downloaded from [Julian McAuley's site](http://jmcauley.ucsd.edu/data/amazon/links.html) using `code/amz-reviews-to-strict-json.py`. Then you should be able to run the R code, which on my machine takes a few minutes but not terribly long. I'm using a random sample of 4000 reviews to generate the topics.

The last line of the R script serves the HTML file that contains the interactive visualization -- it should open a browser window for you. 
