### PR TITLE
iPython notebook that uses NMF to obtain topic results for subset of …

### DIFF
--- a/notebooks/NMF_exploration.ipynb
+++ b/notebooks/NMF_exploration.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "## Read in Review Files and create a pandas dataframe (code borrowed from Julian McAuley website) ##\n",
+    "import pandas as pd\n",
+    "import gzip\n",
+    "\n",
+    "def parse(path):\n",
+    "  g = gzip.open(path, 'rb')\n",
+    "  for l in g:\n",
+    "    yield eval(l)\n",
+    "\n",
+    "def getDF(path):\n",
+    "  i = 0\n",
+    "  df = {}\n",
+    "  for d in parse(path):\n",
+    "    df[i] = d\n",
+    "    i += 1\n",
+    "  return pd.DataFrame.from_dict(df, orient='index')\n",
+    "\n",
+    "##Make all text lowercase and remove special characters for the review text\n",
+    "food_review = getDF('data/reviews_Grocery_and_Gourmet_Food_5.json.gz')\n",
+    "food_review['reviewText'] = food_review['reviewText'].str.lower()\n",
+    "food_review['reviewText'] = food_review['reviewText'].str.replace(\"'\", \"\")\n",
+    "food_review['reviewText'] = food_review['reviewText'].str.replace('[^a-zA-Z\\s]',' ')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "##Test file:  Exclude five star reviews from 5 Core\n",
+    "food_review_nofive = food_review[food_review['overall'] < 5.0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "##Tokenize review text and stem each individual word for each review\n",
+    "import numpy as np\n",
+    "from nltk import word_tokenize\n",
+    "from nltk.corpus import stopwords\n",
+    "from nltk.stem.lancaster import LancasterStemmer\n",
+    "st = LancasterStemmer()\n",
+    "\n",
+    "tokens = [word_tokenize(review) for review in food_review_nofive['reviewText']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "##Remove stopwords and stem\n",
+    "stopwords = stopwords.words('english')\n",
+    "stemmed_token = np.empty((len(tokens),0)).tolist()\n",
+    "for review in tokens:\n",
+    "    n = tokens.index(review)\n",
+    "    stemmed_token[n] = [st.stem(word) for word in review if word not in stopwords]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "##Manipulate stemmed text to be string instead of list (needed for count vectorizer)\n",
+    "final_review_text = []\n",
+    "for review in stemmed_token:\n",
+    "    for word in review:\n",
+    "        n = review.index(word)\n",
+    "        if n == 0:\n",
+    "            string = review[n]\n",
+    "        else:\n",
+    "            string = string + \" \" + review[n]\n",
+    "    final_review_text.append(string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "##Count Vectorizer Matrix\n",
+    "import numpy as np\n",
+    "import scipy\n",
+    "from scipy.sparse import coo_matrix, vstack\n",
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "\n",
+    "vectorizer = CountVectorizer(binary=False, ngram_range=(1, 1)) ##Removed stopwords before stemming so don't apply here\n",
+    "food_review_text = vectorizer.fit_transform(final_review_text)\n",
+    "\n",
+    "##Remove if word is in less than 10 reviews\n",
+    "counts = scipy.sparse.coo_matrix.sum(food_review_text, axis=0)\n",
+    "food_review_text = np.transpose(vstack([food_review_text,counts]))\n",
+    "food_review_text = pd.DataFrame(food_review_text.todense(), index = vectorizer.get_feature_names())\n",
+    "last_col = food_review_text.shape[1] - 1\n",
+    "food_review_text = food_review_text[food_review_text[last_col] > 9]\n",
+    "del food_review_text[last_col]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<63808x6248 sparse matrix of type '<class 'numpy.float64'>'\n",
+       "\twith 2255039 stored elements in Compressed Sparse Column format>"
+      ]
+     },
+     "execution_count": 105,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "##TFIDF Weighting\n",
+    "from sklearn.feature_extraction.text import TfidfTransformer\n",
+    "transformer = TfidfTransformer()\n",
+    "weighted_food_review_text = transformer.fit_transform(food_review_text)\n",
+    "tfidf_matrix = weighted_food_review_text.transpose()\n",
+    "tfidf_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "##Non-negative matrix factorization\n",
+    "n_topics = 15\n",
+    "\n",
+    "from sklearn.decomposition import NMF\n",
+    "model = NMF(init=\"nndsvd\", n_components=n_topics, random_state=1)\n",
+    "W_matrix = model.fit_transform(tfidf_matrix)\n",
+    "H_matrix = model.components_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Topic 0: eat, snack, chocol, lik, pack, good, box, bar, would, tast\n",
+      "Topic 1: chia, nutry, gr, worthless, cashewc, hemp, insulin, flax, regardless, phytosterol\n",
+      "Topic 2: roastgreen, diamondgreen, magicoth, revvgreen, veronastarbuck, mahogony, reservegreen, roaststarbuck, lodg, kop\n",
+      "Topic 3: mickleg, boson, sir, majesty, mangosteen, langu, fij, legend, journey, you\n",
+      "Topic 4: hydrochlorid, niacinamid, riboflavin, palmit, thiamin, biotin, pyridoxin, fol, sulf, acet\n",
+      "Topic 5: wedderspoon, scab, unt, eu, unfilt, pol, honey, rejuv, stamp, ass\n",
+      "Topic 6: compass, gratitud, uplift, soul, grac, wisdom, anch, prevail, enlight, attitud\n",
+      "Topic 7: enzymolys, cfr, oleoresin, der, unexplain, constitu, thereof, poultry, distil, bark\n",
+      "Topic 8: preterm, newborn, inf, vuln, cocain, mo, docosahexaeno, cholin, polysaccharid, synthes\n",
+      "Topic 9: umam, glutam, arroz, inosin, msg, autolys, silicon, mi, brothy, overus\n",
+      "Topic 10: gprotein, mgtotal, gsug, gcholesterol, gsat, mgsodium, gtrans, gdiet, gmonouns, mgpotassium\n",
+      "Topic 11: utf, www, http, gp, sr, dp, ie, pr, ref, keyword\n",
+      "Topic 12: coff, cup, brew, keurig, roast, ground, filt, machin, blend, med\n",
+      "Topic 13: drink, juic, energy, wat, caffein, carbon, sweet, tast, bottl, sug\n",
+      "Topic 14: sauc, cook, dish, past, ad, chick, minut, prep, heat, tomato\n"
+     ]
+    }
+   ],
+   "source": [
+    "feature_names = food_review_text.index\n",
+    "for topic_index in range( H_matrix.shape[0] ):\n",
+    "    top_indices = np.argsort( H_matrix[topic_index,:] )[::-1][0:10]  ##show top 10 words associated with each topic\n",
+    "    term_ranking = [feature_names[i] for i in top_indices]\n",
+    "    print (\"Topic %d: %s\" % ( topic_index, \", \".join( term_ranking ) ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>reviewerID</th>\n",
+       "      <th>reviewText</th>\n",
+       "      <th>reviewTime</th>\n",
+       "      <th>asin</th>\n",
+       "      <th>helpful</th>\n",
+       "      <th>summary</th>\n",
+       "      <th>reviewerName</th>\n",
+       "      <th>overall</th>\n",
+       "      <th>unixReviewTime</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>45163</th>\n",
+       "      <td>A26NFIQ7KWI8Y7</td>\n",
+       "      <td>I'm not a fan of decaf.  This one is drinkable with just a tinge of \"conference coffee\" taste.  I also like Green Mountain Dark Magic Decaf.For reference purposes my in store drink is a Starbucks Americano.My favorite k-cups are:Starbucks French RoastStarbucks Caffe VeronaStarbucks Pike Place RoastGreen Mountain Xtra Bold Sumatran ReserveGreen Mountain Double Black DiamondGreen Mountain RevvGreen Mountain Dark MagicOther k-cups I've tried:  Coffee People Jet Fuel ,Green Mountain Dark Magic Decaf, Starbucks Caffe Verona, Coffee People Black Tiger,  Starbucks House Blend, Starbucks Breakfast Blend, Starbucks Sumatra, Wolfgang Puck French Roast, Green Mountain Lake and Lodge, Green Mountain French Roast, Caribou Mahogony, Wolfgang Puck Sumatra Kopi Raya, Emeril Big Easy Bold</td>\n",
+       "      <td>02 20, 2012</td>\n",
+       "      <td>B001D0GVAO</td>\n",
+       "      <td>[0, 0]</td>\n",
+       "      <td>drinkable for decaf</td>\n",
+       "      <td>kt rose</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1329696000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           reviewerID  \\\n",
+       "45163  A26NFIQ7KWI8Y7   \n",
+       "\n",
+       "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           reviewText  \\\n",
+       "45163  I'm not a fan of decaf.  This one is drinkable with just a tinge of \"conference coffee\" taste.  I also like Green Mountain Dark Magic Decaf.For reference purposes my in store drink is a Starbucks Americano.My favorite k-cups are:Starbucks French RoastStarbucks Caffe VeronaStarbucks Pike Place RoastGreen Mountain Xtra Bold Sumatran ReserveGreen Mountain Double Black DiamondGreen Mountain RevvGreen Mountain Dark MagicOther k-cups I've tried:  Coffee People Jet Fuel ,Green Mountain Dark Magic Decaf, Starbucks Caffe Verona, Coffee People Black Tiger,  Starbucks House Blend, Starbucks Breakfast Blend, Starbucks Sumatra, Wolfgang Puck French Roast, Green Mountain Lake and Lodge, Green Mountain French Roast, Caribou Mahogony, Wolfgang Puck Sumatra Kopi Raya, Emeril Big Easy Bold   \n",
+       "\n",
+       "        reviewTime        asin helpful              summary reviewerName  \\\n",
+       "45163  02 20, 2012  B001D0GVAO  [0, 0]  drinkable for decaf  kt rose       \n",
+       "\n",
+       "       overall  unixReviewTime  \n",
+       "45163  3.0      1329696000      "
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "##For testing - this review had strange text after removing special characters\n",
+    "#food_review[food_review.reviewText.str.contains('veronastarbuck')]\n",
+    "food_review[45163:45164]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
I've adjusted my code so now we can run NMF relatively quickly on the review data.  The attached notebook looks at a subset of the review data (5-core, excluding 5 star reviews) and does the following:
1. Removes english language "stop words" (e.g., 'and' and 'the') and stems the remaining words (e.g., 'vomiting' = 'vomit')
2.  Removes all words that appear in less than 10 reviews
3.  Creates a TF-IDF weighted document-term frequency matrix
4.  Computes non-negative matrix factorization to create the top 15 'topics' with 10 key words for each topic

This methodology seems to do a decent job of identifying product types (e.g.,Topic 12: coff, cup, brew, keurig, roast, ground, filt, machin, blend) but the results do not seem too useful for our categorization purposes.  However, some of the resulting topics reveal some issues that we may have to work through in terms of data-cleaning.  For example,  Topic 2 seems to represent Starbucks reviews, but the words with the highest impact come from a single review that includes some odd words (e.g., veronastarbuck, reservegreen).  From looking at the raw text file, it appears that the user had a list with returns, but the 'reviewText' doesn't treat returns as spaces (i.e., My favorite k-cups are: Starbucks French RoastStarbucks Caffe VeronaStarbucks Pike Place RoastGreen Mountain Xtra Bold....).

Feel free to play around with the notebook (e.g., change n-grams, different subsets) and see what happens!  
