### PR TITLE
Updated code to clean raw review text

### DIFF
--- a/notebooks/NMF_exploration.ipynb
+++ b/notebooks/NMF_exploration.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -25,16 +25,25 @@
     "    i += 1\n",
     "  return pd.DataFrame.from_dict(df, orient='index')\n",
     "\n",
-    "##Make all text lowercase and remove special characters for the review text\n",
-    "food_review = getDF('data/reviews_Grocery_and_Gourmet_Food_5.json.gz')\n",
-    "food_review['reviewText'] = food_review['reviewText'].str.lower()\n",
+    "food_review = getDF('../data/reviews_Grocery_and_Gourmet_Food_5.json.gz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "##Remove special characters for the review text\n",
     "food_review['reviewText'] = food_review['reviewText'].str.replace(\"'\", \"\")\n",
     "food_review['reviewText'] = food_review['reviewText'].str.replace('[^a-zA-Z\\s]',' ')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -46,25 +55,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "##Tokenize review text and stem each individual word for each review\n",
+    "##Tokenize review text for each review\n",
     "import numpy as np\n",
     "from nltk import word_tokenize\n",
     "from nltk.corpus import stopwords\n",
     "from nltk.stem.lancaster import LancasterStemmer\n",
     "st = LancasterStemmer()\n",
     "\n",
-    "tokens = [word_tokenize(review) for review in food_review_nofive['reviewText']]"
+    "tokens_I = [word_tokenize(review) for review in food_review_nofive['reviewText']]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "##Separate strings with multiple uppercase characters (e.g., gCholesterol, VeronaStarbucks).  This should (hopefully)\n",
+    "## take care of situations where the reviews included returns that were not treated as spaces in the raw text file\n",
+    "import re\n",
+    "def split_uppercase(value):\n",
+    "    return re.sub(r'([A-Z])', r' \\1', value)\n",
+    "\n",
+    "tokens_II = np.empty((len(tokens_I),0)).tolist()\n",
+    "for review in tokens_I:\n",
+    "    n = tokens_I.index(review)\n",
+    "    tokens_II[n] = [split_uppercase(word) for word in review]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "##Make all text lower case\n",
+    "tokens = np.empty((len(tokens_II),0)).tolist()\n",
+    "for review in tokens_II:\n",
+    "    n = tokens_II.index(review)\n",
+    "    tokens[n] = [word.lower() for word in review]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -80,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -100,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -126,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -134,11 +178,11 @@
     {
      "data": {
       "text/plain": [
-       "<63808x6248 sparse matrix of type '<class 'numpy.float64'>'\n",
-       "\twith 2255039 stored elements in Compressed Sparse Column format>"
+       "<63808x7051 sparse matrix of type '<class 'numpy.float64'>'\n",
+       "\twith 2061758 stored elements in Compressed Sparse Column format>"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,14 +198,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "##Non-negative matrix factorization\n",
-    "n_topics = 15\n",
+    "n_topics = 20\n",
     "\n",
     "from sklearn.decomposition import NMF\n",
     "model = NMF(init=\"nndsvd\", n_components=n_topics, random_state=1)\n",
@@ -171,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -180,98 +224,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Topic 0: eat, snack, chocol, lik, pack, good, box, bar, would, tast\n",
-      "Topic 1: chia, nutry, gr, worthless, cashewc, hemp, insulin, flax, regardless, phytosterol\n",
-      "Topic 2: roastgreen, diamondgreen, magicoth, revvgreen, veronastarbuck, mahogony, reservegreen, roaststarbuck, lodg, kop\n",
-      "Topic 3: mickleg, boson, sir, majesty, mangosteen, langu, fij, legend, journey, you\n",
-      "Topic 4: hydrochlorid, niacinamid, riboflavin, palmit, thiamin, biotin, pyridoxin, fol, sulf, acet\n",
-      "Topic 5: wedderspoon, scab, unt, eu, unfilt, pol, honey, rejuv, stamp, ass\n",
-      "Topic 6: compass, gratitud, uplift, soul, grac, wisdom, anch, prevail, enlight, attitud\n",
-      "Topic 7: enzymolys, cfr, oleoresin, der, unexplain, constitu, thereof, poultry, distil, bark\n",
-      "Topic 8: preterm, newborn, inf, vuln, cocain, mo, docosahexaeno, cholin, polysaccharid, synthes\n",
-      "Topic 9: umam, glutam, arroz, inosin, msg, autolys, silicon, mi, brothy, overus\n",
-      "Topic 10: gprotein, mgtotal, gsug, gcholesterol, gsat, mgsodium, gtrans, gdiet, gmonouns, mgpotassium\n",
-      "Topic 11: utf, www, http, gp, sr, dp, ie, pr, ref, keyword\n",
-      "Topic 12: coff, cup, brew, keurig, roast, ground, filt, machin, blend, med\n",
-      "Topic 13: drink, juic, energy, wat, caffein, carbon, sweet, tast, bottl, sug\n",
-      "Topic 14: sauc, cook, dish, past, ad, chick, minut, prep, heat, tomato\n"
+      "Topic 0: eat, snack, the, chocol, pack, they, bar, lik, box, good\n",
+      "Topic 1: nutry, insulin, canyon, worthless, cm, sesam, hemp, highest, rancid, regardless\n",
+      "Topic 2: mahogony, lodge, kopi, raya, jazzed, emeril, xtra, wolfgang, mountain, reserve\n",
+      "Topic 3: folic, sodium, color, calcium, sugars, mononitrate, niacinamide, dietary, total, sulfate\n",
+      "Topic 4: compass, gratitud, uplift, soul, wisdom, prevail, grac, enlight, attitud, mercy\n",
+      "Topic 5: unfiltered, unrefined, unknown, fahrenheit, virgin, trade, press, certified, kosher, unrefin\n",
+      "Topic 6: preterm, newborn, scientists, cocain, vuln, infant, mo, inf, cholin, polysaccharid\n",
+      "Topic 7: sprats, baltic, filet, fish, her, fillets, kipper, fillet, seas, herring\n",
+      "Topic 8: umam, glutam, inosin, arroz, silicon, autolys, overus, disod, dioxid, mi\n",
+      "Topic 9: regulations, federal, enzymolys, unexplain, code, oleoresin, der, constitu, thereof, poultry\n",
+      "Topic 10: sauc, cook, dish, ad, past, chick, minut, prep, heat, tomato\n",
+      "Topic 11: ikkoku, maison, exquisit, celest, rendit, deplet, sencha, enorm, altitud, en\n",
+      "Topic 12: citicolin, nawgan, cognizin, mikes, hydrochlorid, pyridoxin, alph, acet, carot, cyanocobalamin\n",
+      "Topic 13: brite, cleaner, scotch, pad, cle, scrubbing, buff, scrubber, cooktop, stov\n",
+      "Topic 14: defec, phytosterols, musc, chia, eicosapentaeno, chi, gr, unw, docosahexaeno, omeg\n",
+      "Topic 15: erythritol, nectresse, sucros, monk, nectress, menthol, sug, sweet, swerve, stev\n",
+      "Topic 16: diatomac, wedderspoon, scab, pol, unfilt, ass, honey, rejuv, purchasing, viscos\n",
+      "Topic 17: drink, tea, energy, wat, tast, caffein, juic, flav, bottl, lik\n",
+      "Topic 18: stream, liter, markup, brita, costs, restaurant, refil, soda, lit, sixteen\n",
+      "Topic 19: coff, cup, brew, keurig, coffee, roast, ground, filt, machin, blend\n"
      ]
     }
    ],
    "source": [
+    "##Prints tops and keywords\n",
+    "\n",
     "feature_names = food_review_text.index\n",
     "for topic_index in range( H_matrix.shape[0] ):\n",
     "    top_indices = np.argsort( H_matrix[topic_index,:] )[::-1][0:10]  ##show top 10 words associated with each topic\n",
     "    term_ranking = [feature_names[i] for i in top_indices]\n",
     "    print (\"Topic %d: %s\" % ( topic_index, \", \".join( term_ranking ) ))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 98,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>reviewerID</th>\n",
-       "      <th>reviewText</th>\n",
-       "      <th>reviewTime</th>\n",
-       "      <th>asin</th>\n",
-       "      <th>helpful</th>\n",
-       "      <th>summary</th>\n",
-       "      <th>reviewerName</th>\n",
-       "      <th>overall</th>\n",
-       "      <th>unixReviewTime</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>45163</th>\n",
-       "      <td>A26NFIQ7KWI8Y7</td>\n",
-       "      <td>I'm not a fan of decaf.  This one is drinkable with just a tinge of \"conference coffee\" taste.  I also like Green Mountain Dark Magic Decaf.For reference purposes my in store drink is a Starbucks Americano.My favorite k-cups are:Starbucks French RoastStarbucks Caffe VeronaStarbucks Pike Place RoastGreen Mountain Xtra Bold Sumatran ReserveGreen Mountain Double Black DiamondGreen Mountain RevvGreen Mountain Dark MagicOther k-cups I've tried:  Coffee People Jet Fuel ,Green Mountain Dark Magic Decaf, Starbucks Caffe Verona, Coffee People Black Tiger,  Starbucks House Blend, Starbucks Breakfast Blend, Starbucks Sumatra, Wolfgang Puck French Roast, Green Mountain Lake and Lodge, Green Mountain French Roast, Caribou Mahogony, Wolfgang Puck Sumatra Kopi Raya, Emeril Big Easy Bold</td>\n",
-       "      <td>02 20, 2012</td>\n",
-       "      <td>B001D0GVAO</td>\n",
-       "      <td>[0, 0]</td>\n",
-       "      <td>drinkable for decaf</td>\n",
-       "      <td>kt rose</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>1329696000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           reviewerID  \\\n",
-       "45163  A26NFIQ7KWI8Y7   \n",
-       "\n",
-       "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           reviewText  \\\n",
-       "45163  I'm not a fan of decaf.  This one is drinkable with just a tinge of \"conference coffee\" taste.  I also like Green Mountain Dark Magic Decaf.For reference purposes my in store drink is a Starbucks Americano.My favorite k-cups are:Starbucks French RoastStarbucks Caffe VeronaStarbucks Pike Place RoastGreen Mountain Xtra Bold Sumatran ReserveGreen Mountain Double Black DiamondGreen Mountain RevvGreen Mountain Dark MagicOther k-cups I've tried:  Coffee People Jet Fuel ,Green Mountain Dark Magic Decaf, Starbucks Caffe Verona, Coffee People Black Tiger,  Starbucks House Blend, Starbucks Breakfast Blend, Starbucks Sumatra, Wolfgang Puck French Roast, Green Mountain Lake and Lodge, Green Mountain French Roast, Caribou Mahogony, Wolfgang Puck Sumatra Kopi Raya, Emeril Big Easy Bold   \n",
-       "\n",
-       "        reviewTime        asin helpful              summary reviewerName  \\\n",
-       "45163  02 20, 2012  B001D0GVAO  [0, 0]  drinkable for decaf  kt rose       \n",
-       "\n",
-       "       overall  unixReviewTime  \n",
-       "45163  3.0      1329696000      "
-      ]
-     },
-     "execution_count": 98,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "##For testing - this review had strange text after removing special characters\n",
-    "#food_review[food_review.reviewText.str.contains('veronastarbuck')]\n",
-    "food_review[45163:45164]"
    ]
   },
   {


### PR DESCRIPTION
I updated the code to separate strings that are off because returns weren't treated as spaces in the raw text file (e.g., veronaStarbucks = verona Starbuck).  It seems to get rid of the weird 'non-word' topics that I was running into yesterday.  Only downside is cleaning the data takes a little bit longer now....
