### PR TITLE
join metadata to review-recall df

### DIFF
--- a/notebooks/join_review-recall notebook.ipynb
+++ b/notebooks/join_review-recall notebook.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -76,6 +76,13 @@
    "outputs": [],
    "source": [
     "df = getDF(os.path.join(data_dir, \"reviews_Grocery_and_Gourmet_Food.json.gz\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Add recall info"
    ]
   },
   {
@@ -213,6 +220,35 @@
    "outputs": [],
    "source": [
     "recall = rev_recall.groupby([\"recalled\"]).get_group(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Add metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "metadata = getDF(os.path.join(data_dir, \"meta_Grocery_and_Gourmet_Food.json.gz\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "full_df = pd.merge(rev_recall, metadata_col_subset, how = \"left\", on = [\"asin\"])"
    ]
   }
  ],


### PR DESCRIPTION
updated join notebook to add metadata columns to review-recall dataframe. metadata is read in from `meta_Grocery_and_Gourmet_Food.json.gz` downloaded from http://jmcauley.ucsd.edu/data/amazon/links.html under heading: "Per-Category files:  Grocery and Gourmet Food: metadata (171,760 products)"
