### PR TITLE
Fix count of non-recalled product reviews

### DIFF
--- a/notebooks/review_summary_vis.Rmd
+++ b/notebooks/review_summary_vis.Rmd
@@ -64,7 +64,7 @@ mytheme <- theme_update(
 
 ```{r review-counts, echo = FALSE}
 recalled_count <- nrow(amz_clean[amz_clean$recall == "Recalled", ])
-nonrecalled_count <- nrow(amz_clean[amz_clean$recall == "Not Recalled", ])
+nonrecalled_count <- nrow(amz_clean[amz_clean$recall == "Not recalled", ])
 ```
 
 There are a total of `r recalled_count` reviews for recalled food products and

--- a/notebooks/review_summary_vis.md
+++ b/notebooks/review_summary_vis.md
@@ -57,7 +57,7 @@ mytheme <- theme_update(
 Review counts of recalled vs. non-recalled products
 ---------------------------------------------------
 
-There are a total of 1638 reviews for recalled food products and 0 reviews for non-recalled food products.
+There are a total of 1638 reviews for recalled food products and 1295518 reviews for non-recalled food products.
 
 ``` r
 ggplot(amz_clean, aes(x = recall, fill = recall)) +


### PR DESCRIPTION
A mistake in the code made the text say there were zero reviews for non-recalled products, which is obviously not true.
