### PR TITLE
Put "Future Directions" page last in menu

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -18,13 +18,15 @@
 
     {% assign pages_list = site.pages | sort:"url" %}
     {% for node in pages_list %}
-      {% if node.title != null %}
+      {% if node.title != null and node.title != "Future directions"%}
         {% if node.layout == "page" %}
           <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url | prepend: site.github.url }}">{{ node.title }}</a>
         {% endif %}
       {% endif %}
     {% endfor %}
-
+          
+    <a class="sidebar-nav-item" href="{{ site.github.url }}/future-directions">Future directions</a>
+                    
     <a class="sidebar-nav-item" href="https://github.com/uwescience/DSSG2016-UnsafeFoods">GitHub repository</a>
     
   </nav>


### PR DESCRIPTION
Right now pages are listed alphabetically, but it doesn't make sense to have the Future Directions page show up before some of the other pages about what we did this summer, so I moved it to the end of the list (just before the GitHub repository link).
