### PR TITLE
Remove Future Directions from sidebar for now

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -27,10 +27,10 @@
       {% endfor %}
 
             <!-- Future directions -->
-            <a class="sidebar-nav-item"
-               href="{{ site.baseurl }}/future-directions">
-              Future directions
-            </a>
+            <!-- <a class="sidebar-nav-item" -->
+            <!--    href="{{ site.baseurl }}/future-directions"> -->
+            <!--   Future directions -->
+            <!-- </a> -->
 
             <!-- Github repo -->
             <a class="sidebar-nav-item"


### PR DESCRIPTION
I removed the Future Directions page in my last PR because it was empty, but I forgot to remove it from the sidebar.
